### PR TITLE
use https onkiFrontendUrl when onki-selector.js is loaded over https

### DIFF
--- a/widget/selector/onki-selector.js.php
+++ b/widget/selector/onki-selector.js.php
@@ -42,16 +42,18 @@ list($temp, $cacheid) = explode(".", microtime(true));
 var host = "<?php echo $baseurl ?>";
 var ysourl = "<?php echo $onkiurl ?>";
 var onkiFrontendUrl = "<?php echo $onkiHttpApiUrl ?>"; // onki frontend http get api
-onkiFrontendUrl = "http://onki.fi/api/v2/http/repo/"; 
+onkiFrontendUrl = "onki.fi/api/v2/http/repo/";
 
 var fintoApiUrl = "://api.finto.fi/rest/v1/";
 if ("https:" == document.location.protocol) {
   host = 'https://' + host;
   ysourl = 'https://' + ysourl;
+  onkiFrontendUrl = 'https://' + onkiFrontendUrl;
   fintoApiUrl = 'https' + fintoApiUrl;
 } else {
   host = 'http://' + host;
   ysourl = 'http://' + ysourl;
+  onkiFrontendUrl = 'http://' + onkiFrontendUrl;
   fintoApiUrl = 'http' + fintoApiUrl;
 }  
 


### PR DESCRIPTION
Fixes the Mixed content error issue, e.g., on ONKI Selector integration code generator page:
1. Go to https://onki.fi/widget/selector/?l=en
2. Select Ontology (widget's dropdown menu): "all"
3. See the Mixed content error in browser console:
`Mixed Content: The page at 'https://onki.fi/widget/selector/?l=en' was loaded over HTTPS, but requested an insecure script 'http://onki.fi/api/v2/http/repo/languages?callback=onkiSearch[%27ysoSearch%27].setLangs'. This request has been blocked; the content must be served over HTTPS.`